### PR TITLE
feature/JwtAuthenticationFilter

### DIFF
--- a/src/main/java/com/gnakkeoyhgnus/noteforios/config/SecurityConfig.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/config/SecurityConfig.java
@@ -1,16 +1,24 @@
 package com.gnakkeoyhgnus.noteforios.config;
 
+import com.gnakkeoyhgnus.noteforios.jwt.JwtAuthenticationFilter;
+import com.gnakkeoyhgnus.noteforios.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtTokenProvider jwtTokenProvider;
 
   @Bean
   PasswordEncoder passwordEncoder() {
@@ -21,10 +29,16 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
         .csrf().disable()
+        .sessionManagement(sessionManagement ->
+            sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeRequests(auth -> auth
             .antMatchers("/", "/v1/user/sign**").permitAll()
             .anyRequest().authenticated()
-        );
+        )
+        .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+            UsernamePasswordAuthenticationFilter.class)
+
+    ;
 
     return http.build();
   }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/controller/UserController.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/controller/UserController.java
@@ -7,6 +7,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +38,12 @@ public class UserController {
     headers.add(HttpHeaders.AUTHORIZATION, token);
 
     return ResponseEntity.ok().headers(headers).body(null);
+  }
+
+  @GetMapping("/test")
+  public ResponseEntity<String> test() {
+
+    return ResponseEntity.ok("테스트");
   }
 
 }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/exception/ErrorCode.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/exception/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
 
   //로그인
   MISMATCH_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "이메일이나 비밀번호가 일치하지 않습니다."),
-  NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "유저를 찾을 수 없습니다.")
+  NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "유저를 찾을 수 없습니다."),
+
+  //토큰
+  INVALID_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다.")
 
   ;
 

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.gnakkeoyhgnus.noteforios.jwt;
+
+import com.gnakkeoyhgnus.noteforios.exception.CustomException;
+import com.gnakkeoyhgnus.noteforios.exception.ErrorCode;
+import java.io.IOException;
+import java.util.Optional;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    Optional<String> token = JwtTokenProvider.resolveToken(request);
+    if (token.isEmpty()) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String email = jwtTokenProvider.getEmail(token.get());
+    log.info("[JwtAuthenticationFilter] TokenVerify 시작 Email : " + email);
+
+    if (!jwtTokenProvider.isTokenValid(token.get())) {
+      log.info("[JwtAuthenticationFilter] TokenVerify 실패 Email : " + email);
+      throw new CustomException(ErrorCode.INVALID_TOKEN);
+    }
+
+    log.info("[JwtAuthenticationFilter] TokenVerify 완료 Email : " + email);
+    SecurityContextHolder.getContext().setAuthentication(
+        jwtTokenProvider.getAuthentication(token.get()));
+    filterChain.doFilter(request, response);
+  }
+
+}

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/jwt/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.gnakkeoyhgnus.noteforios.config.jwt;
+package com.gnakkeoyhgnus.noteforios.jwt;
 
 
 import com.auth0.jwt.JWT;
@@ -6,13 +6,28 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import com.gnakkeoyhgnus.noteforios.domain.entity.User;
+import com.gnakkeoyhgnus.noteforios.domain.repository.UserRepository;
+import com.gnakkeoyhgnus.noteforios.exception.CustomException;
+import com.gnakkeoyhgnus.noteforios.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtTokenProvider {
 
   @Value("${spring.jwt.secret-key}")
@@ -20,6 +35,8 @@ public class JwtTokenProvider {
 
   @Value("${spring.jwt.expiration}")
   private Long accessTokenExpireTime;
+
+  private final UserRepository userRepository;
 
   private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
   private static final String EMAIL_CLAIM = "email";
@@ -44,7 +61,6 @@ public class JwtTokenProvider {
 
     try {
       token = token.substring(PREFIX.length());
-      JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
 
       log.info("[Token Valid] Token 검증 완료 : " + token);
       return true;
@@ -53,18 +69,35 @@ public class JwtTokenProvider {
     } catch (TokenExpiredException e) {
       log.error("[Token expired] : " + e.getMessage());
     } catch (Exception e) {
-      log.error("[Invalid token] : "+ e.getMessage());
+      log.error("[Invalid token] : " + e.getMessage());
     }
 
-    log.info("[Token Valid] Token 검증 실패 : " + token);
+    log.error("[Token Valid] Token 검증 실패 : " + token);
     return false;
+  }
+
+  public Authentication getAuthentication(String token) {
+
+    String email = getEmail(token);
+
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(new SimpleGrantedAuthority(user.getRole().toString()));
+
+    return new UsernamePasswordAuthenticationToken(user, "", authorities);
   }
 
   public String getEmail(String token) {
     token = token.substring(PREFIX.length());
     DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(secretKey)).build().verify(token);
 
-    return decodedJWT.getClaim("email").toString();
+    return decodedJWT.getClaim(EMAIL_CLAIM).asString();
+  }
+
+  public static Optional<String> resolveToken(HttpServletRequest request) {
+    return Optional.ofNullable(request.getHeader(HttpHeaders.AUTHORIZATION));
   }
 
 }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/service/UserService.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/service/UserService.java
@@ -1,6 +1,6 @@
 package com.gnakkeoyhgnus.noteforios.service;
 
-import com.gnakkeoyhgnus.noteforios.config.jwt.JwtTokenProvider;
+import com.gnakkeoyhgnus.noteforios.jwt.JwtTokenProvider;
 import com.gnakkeoyhgnus.noteforios.domain.constants.RoleType;
 import com.gnakkeoyhgnus.noteforios.domain.entity.User;
 import com.gnakkeoyhgnus.noteforios.domain.form.SignInForm;


### PR DESCRIPTION
## JwtAuthenticationFilter
- JwtAuthenticationFilter 구현하여 JwtToken Validate하도록 함
- request header에 token이 없을 시 doFilter로 바로 다음으로 넘어가도록 함

## 배운점
- SecurityConfig에서 http 설정 시에 antMatchers에 경로를 설정했을 때 Filter는 지나가는 것을 배웠다. 이전에는 Web으로 ignore를 설정해주고 왜 안 되는지는 모르고 지나갔는데 이번 기회에 이해했다. 하여 이번에는 web ignore로 하지 않고 Request header에 token이 없을 시 dofilter로 다음 단계로 넘어가도록 했다.