### PR TITLE
Hotfix/update page share board

### DIFF
--- a/src/main/java/com/gnakkeoyhgnus/noteforios/controller/ImageUploadController.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/controller/ImageUploadController.java
@@ -1,12 +1,14 @@
 package com.gnakkeoyhgnus.noteforios.controller;
 
 import com.gnakkeoyhgnus.noteforios.domain.entity.User;
+import com.gnakkeoyhgnus.noteforios.domain.form.DeleteImageForm;
 import com.gnakkeoyhgnus.noteforios.service.AmazonS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,9 +28,9 @@ public class ImageUploadController {
   }
 
   @DeleteMapping
-  public ResponseEntity<Void> uploadImage(String fileKey) {
+  public ResponseEntity<Void> deleteImage(@RequestBody DeleteImageForm deleteImageForm) {
 
-    amazonS3Service.deleteUploadFile(fileKey);
+    amazonS3Service.deleteUploadFile(deleteImageForm.getFileKey());
 
     return ResponseEntity.ok(null);
   }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/domain/entity/PageShareBoard.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/domain/entity/PageShareBoard.java
@@ -1,6 +1,7 @@
 package com.gnakkeoyhgnus.noteforios.domain.entity;
 
 import com.gnakkeoyhgnus.noteforios.domain.form.UpdatePageShareBoardForm;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -26,6 +27,7 @@ public class PageShareBoard extends BaseTimeEntity {
 
   private String title;
 
+  @Column(columnDefinition = "text")
   private String explains;
 
   private String thumbnailUrl;

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/domain/entity/User.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/domain/entity/User.java
@@ -44,4 +44,8 @@ public class User extends BaseTimeEntity {
   @Enumerated(EnumType.STRING)
   private RoleType role;
 
+  public void setProfileImageUrl(String profileImageUrl) {
+    this.profileImageUrl = profileImageUrl;
+  }
+
 }

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/domain/form/DeleteImageForm.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/domain/form/DeleteImageForm.java
@@ -1,0 +1,14 @@
+package com.gnakkeoyhgnus.noteforios.domain.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class DeleteImageForm {
+
+  private String fileKey;
+
+}

--- a/src/main/java/com/gnakkeoyhgnus/noteforios/service/UserService.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/service/UserService.java
@@ -46,19 +46,20 @@ public class UserService {
         });
 
     log.info("[signUp] 회원가입 완료 Email : " + signUpForm.getEmail());
-    userRepository.save(User.builder()
+    User user = userRepository.save(User.builder()
         .email(signUpForm.getEmail())
         .password(passwordEncoder.encode(signUpForm.getPassword()))
         .name(signUpForm.getName())
         .nickname(signUpForm.getNickname())
         .phoneNumber(signUpForm.getPhoneNumber())
-        .profileImageUrl(profileImage.isEmpty() ?
-            defaultProfileImage : amazonS3Service.uploadForProfile(profileImage, signUpForm.getEmail())
-        )
         .role(RoleType.USER)
         .emailVerified(false)
         .emailVerifiedCode(RandomString.make(5))
         .build());
+
+    user.setProfileImageUrl(profileImage.isEmpty() ?
+        defaultProfileImage : amazonS3Service.uploadForProfile(profileImage, user.getId())
+    );
   }
 
   public String signIn(SignInForm signInForm) {

--- a/src/test/java/com/gnakkeoyhgnus/noteforios/service/UserServiceTest.java
+++ b/src/test/java/com/gnakkeoyhgnus/noteforios/service/UserServiceTest.java
@@ -57,7 +57,7 @@ class UserServiceTest {
 
     MultipartFile multipartFile = mock(MultipartFile.class);
 
-    when(amazonS3Service.uploadForProfile(any(MultipartFile.class), any(String.class)))
+    when(amazonS3Service.uploadForProfile(any(MultipartFile.class), any(Long.class)))
         .thenReturn("uploadUrl");
 
     //when


### PR DESCRIPTION
### S3 ImageUpload
- 업로드 시 유저의 이메일로 경로를 설정했으나, Image의 Key가 생성될 때 이메일에 들어가는 특수문자'@'를 '%40'으로 변경되어 생성되어 정상 작동이 안 됨
-> 들어가는 키 Email에서 userId로 변경

### S3 ImageDelete
- S3에 업로드된 이미지를 삭제 시 받는 파일 키가 인자 하나로 받을 시 Json으로 파싱해야 하여 Parsing 보다는 DeleteImageForm을 생성하여 해결

### 트러블 슈팅
- PageShareBoard의 Explains에 들어가는 내용은 사진의 URL도 포함되어 있어 글자 수가 많음. 하여 생성이나 수정 시에 사진이나 글을 많이 쓴다면 저장이 되지 않는 문제 발생
-> 확인해보니 생성 시에 varchar(255)로 되어 255글자만 받을 수 있도록 됨.
-> text로 변경하여 255 제한점 해결

- 이미지 업로드 시 유저의 이메일이 경로로 들어가게 설정했으나, Image의 Key가 생성될 때 이메일에 들어가는 특수문자'@'를 '%40'으로 변경되어 DB에 들어가게 되어 정상 작동이 안 됨
-> 들어가는 키 Email에서 userId로 변경