### PR TITLE
hotfix/SignInTest_Fail

### DIFF
--- a/src/main/java/com/gnakkeoyhgnus/noteforios/service/UserService.java
+++ b/src/main/java/com/gnakkeoyhgnus/noteforios/service/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
   @Value("${profile.image.default}")
   private String defaultProfileImage;
 
+  @Transactional
   public void signUp(SignUpForm signUpForm, MultipartFile profileImage) {
     log.info("[signUp] 회원가입 시작 Email : " + signUpForm.getEmail());
 


### PR DESCRIPTION
### 회원가입 시 프로필 이미지 저장 안 됨
- 테스트 시 프로필 이미지가 저장되지 않아 null 발생하여 Transactional 적용
  - 회원가입 로직이 변경되었는데 여기서 영속성 문제로 profile이 적용되지 않음. 
    - 기존 : userRepository에 save 시 프로필 url 적용 
    - 변경 : userRepository에 프로필 외 save 후 프로필 url 적용